### PR TITLE
Implement community moderation, matching, and Firebase support

### DIFF
--- a/docs/firebase_console_checklist.md
+++ b/docs/firebase_console_checklist.md
@@ -1,0 +1,23 @@
+# Firebase 콘솔 작업 체크리스트
+
+- **Authentication**
+  - 이메일/패스워드 로그인 활성화
+  - (선택) 익명 로그인 활성화
+  - App Check 구성 및 Flutter 앱에 적용
+- **Firestore**
+  - 아래 인덱스 생성
+    1. `posts` – `orderBy(createdAt desc)`
+    2. `posts` – `orderBy(hotScore desc)`
+    3. `posts` – `where(audience=='serial' && serial==X)` + `orderBy(createdAt desc)`
+    4. `posts` – `where(boardId==X)` + `orderBy(createdAt desc)`
+    5. `posts` – `where(tags array-contains)` + `orderBy(createdAt desc)`
+  - 필요 시 TTL 및 백업 정책 검토
+- **Storage**
+  - 규칙 배포: 인증 사용자만 업로드 가능, 이미지 MIME/10MB 제한
+  - 썸네일/원본 업로드 경로(`/post_images/{uid}/{postId}/...`, `/profile_images/{uid}/...`) 확인
+- **Cloud Functions**
+  - `onLikeWrite`, `onCommentWrite`, `onPostWrite` 함수 배포
+  - Functions 로깅/모니터링 알림 설정
+- **추가 확장 기능(옵션)**
+  - Firebase Extensions: 이미지 리사이즈, Algolia 연동 검토
+  - Crashlytics/Analytics 대시보드 알림 구성

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,44 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "hotScore", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "audience", "order": "ASCENDING" },
+        { "fieldPath": "serial", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "boardId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "tags", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,157 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    function getUserDoc(uid) {
+      return get(/databases/$(database)/documents/users/$(uid));
+    }
+
+    function canModerate() {
+      return isSignedIn() && getUserDoc(request.auth.uid).data.role in ['admin', 'moderator'];
+    }
+
+    function canViewPost(postData) {
+      return postData.visibility == 'public' ||
+        (isSignedIn() && (
+          request.auth.uid == postData.authorUid ||
+          canModerate() ||
+          (postData.audience == 'serial' &&
+           getUserDoc(request.auth.uid).data.serial == postData.serial)
+        ));
+    }
+
+    function changedKeys() {
+      return request.resource.data.diff(resource.data).affectedKeys();
+    }
+
+    function unchangedOrIncremented(field, allowNegative) {
+      return !request.resource.data.keys().hasAny([field]) ||
+        request.resource.data[field] == resource.data[field] ||
+        (
+          resource.data[field] is int &&
+          request.resource.data[field] is int &&
+          (
+            request.resource.data[field] == resource.data[field] + 1 ||
+            (allowNegative && request.resource.data[field] == resource.data[field] - 1)
+          )
+        );
+    }
+
+    function isCounterUpdate() {
+      return changedKeys().hasOnly(['likeCount', 'commentCount', 'viewCount', 'updatedAt']) &&
+        unchangedOrIncremented('likeCount', true) &&
+        unchangedOrIncremented('commentCount', true) &&
+        unchangedOrIncremented('viewCount', false);
+    }
+
+    match /users/{uid} {
+      allow read: if isSignedIn();
+      allow create: if isOwner(uid);
+      allow update: if isOwner(uid);
+      allow delete: if isOwner(uid) || canModerate();
+
+      match /badges/{badgeId} {
+        allow read: if isOwner(uid) || canModerate();
+        allow create, update, delete: if isOwner(uid) || canModerate();
+      }
+
+      match /bookmarks/{postId} {
+        allow read, create, update, delete: if isOwner(uid);
+      }
+
+      match /matching_meta/{docId} {
+        allow read, write: if isOwner(uid);
+      }
+
+      match /matching_likes/{targetUid} {
+        allow read, write: if isOwner(uid);
+      }
+
+      match /matching_inbox/{senderUid} {
+        allow read, delete: if isOwner(uid) || canModerate();
+        allow create: if isSignedIn() && request.auth.uid == senderUid;
+      }
+    }
+
+    match /handles/{handle} {
+      allow read: if true;
+      allow create, update: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+      allow delete: if isSignedIn() && resource.data.uid == request.auth.uid;
+    }
+
+    match /boards/{boardId} {
+      allow read: if true;
+      allow write: if canModerate();
+    }
+
+    match /posts/{postId} {
+      allow read: if canViewPost(resource.data);
+      allow create: if isSignedIn() && request.resource.data.authorUid == request.auth.uid;
+      allow update: if isSignedIn() && (
+        (isOwner(resource.data.authorUid) &&
+         request.resource.data.authorUid == resource.data.authorUid) ||
+        canModerate() ||
+        isCounterUpdate()
+      );
+      allow delete: if isOwner(resource.data.authorUid) || canModerate();
+
+      match /comments/{commentId} {
+        allow read: if canViewPost(get(/databases/$(database)/documents/posts/$(postId)).data);
+        allow create: if isSignedIn() && request.resource.data.authorUid == request.auth.uid;
+        allow update, delete: if isSignedIn() &&
+          (request.auth.uid == resource.data.authorUid || canModerate());
+
+        match /comment_likes/{likeId} {
+          allow read: if isSignedIn();
+          allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+          allow delete: if isSignedIn() && resource.data.uid == request.auth.uid;
+        }
+      }
+    }
+
+    match /likes/{likeId} {
+      allow read: if isSignedIn();
+      allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+      allow delete: if isSignedIn() && resource.data.uid == request.auth.uid;
+    }
+
+    match /post_counters/{postId} {
+      allow read: if isSignedIn() || canModerate();
+      allow write: if isSignedIn();
+
+      match /shards/{shardId} {
+        allow read: if isSignedIn() || canModerate();
+        allow write: if isSignedIn();
+      }
+    }
+
+    match /reports/{reportId} {
+      allow create: if isSignedIn();
+      allow read, update, delete: if canModerate();
+    }
+
+    match /search_suggestions/{token} {
+      allow read: if true;
+      allow write: if isSignedIn();
+    }
+
+    match /matches/{matchId} {
+      allow create: if isSignedIn() &&
+        (request.auth.uid == request.resource.data.userA ||
+         request.auth.uid == request.resource.data.userB);
+      allow read, update, delete: if isSignedIn() &&
+        (request.auth.uid == resource.data.userA ||
+         request.auth.uid == resource.data.userB ||
+         canModerate());
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,32 +1,287 @@
-/**
- * Import function triggers from their respective submodules:
- *
- * import {onCall} from "firebase-functions/v2/https";
- * import {onDocumentWritten} from "firebase-functions/v2/firestore";
- *
- * See a full list of supported triggers at https://firebase.google.com/docs/functions
- */
-
 import {setGlobalOptions} from "firebase-functions";
-import {onRequest} from "firebase-functions/https";
+import {onDocumentWritten} from "firebase-functions/v2/firestore";
 import * as logger from "firebase-functions/logger";
+import {initializeApp} from "firebase-admin/app";
+import {FieldValue, Timestamp, getFirestore} from "firebase-admin/firestore";
 
-// Start writing functions
-// https://firebase.google.com/docs/functions/typescript
+type CommentSnapshotData = {
+  text?: string;
+  likeCount?: number;
+  authorNickname?: string;
+  deleted?: boolean;
+};
 
-// For cost control, you can set the maximum number of containers that can be
-// running at the same time. This helps mitigate the impact of unexpected
-// traffic spikes by instead downgrading performance. This limit is a
-// per-function limit. You can override the limit for each function using the
-// `maxInstances` option in the function's options, e.g.
-// `onRequest({ maxInstances: 5 }, (req, res) => { ... })`.
-// NOTE: setGlobalOptions does not apply to functions using the v1 API. V1
-// functions should each use functions.runWith({ maxInstances: 10 }) instead.
-// In the v1 API, each function can only serve one request per container, so
-// this will be the maximum concurrent request count.
-setGlobalOptions({ maxInstances: 10 });
+type PostSnapshotData = {
+  likeCount?: number;
+  commentCount?: number;
+  viewCount?: number;
+  createdAt?: Timestamp | Date | string | number | null;
+  visibility?: string;
+  authorUid?: string;
+  audience?: string;
+  serial?: string;
+  text?: string;
+  authorNickname?: string;
+  tags?: unknown;
+  keywords?: unknown;
+};
 
-// export const helloWorld = onRequest((request, response) => {
-//   logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+const REGION = "asia-northeast3";
+const LIKE_WEIGHT = 3;
+const COMMENT_WEIGHT = 5;
+const VIEW_WEIGHT = 1;
+const DECAY_LAMBDA = 1.2;
+const MAX_KEYWORD_TOKENS = 150;
+const MAX_TOKEN_LENGTH = 20;
+
+setGlobalOptions({region: REGION, maxInstances: 10});
+
+initializeApp();
+const db = getFirestore();
+
+function toDate(value: Timestamp | Date | string | number | null | undefined): Date {
+  if (value instanceof Timestamp) {
+    return value.toDate();
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return new Date(value);
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return new Date();
+}
+
+function calculateHotScore(
+  likeCount: number,
+  commentCount: number,
+  viewCount: number,
+  createdAt: Timestamp | Date | string | number | null | undefined,
+): number {
+  const created = toDate(createdAt);
+  const ageMillis = Date.now() - created.getTime();
+  const hours = ageMillis / (1000 * 60 * 60);
+  const baseScore =
+    likeCount * LIKE_WEIGHT + commentCount * COMMENT_WEIGHT + viewCount * VIEW_WEIGHT;
+  if (!Number.isFinite(hours) || hours <= 0) {
+    return baseScore;
+  }
+  const timeDecay = Math.pow(2, hours / DECAY_LAMBDA);
+  if (!Number.isFinite(timeDecay) || timeDecay <= 0) {
+    return baseScore;
+  }
+  return baseScore / timeDecay;
+}
+
+function normalizeTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const normalized = new Set<string>();
+  for (const value of raw) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const cleaned = value.replace(/^#+/, "").trim().toLowerCase();
+    if (cleaned.length > 0) {
+      normalized.add(cleaned);
+    }
+  }
+  return Array.from(normalized).slice(0, 50);
+}
+
+function tokenize(value: string, collector: Set<string>): void {
+  const segments = value
+    .toLowerCase()
+    .split(/[\s.,!?@#\-_/]+/)
+    .filter((segment) => segment.trim().length > 0);
+  for (const segment of segments) {
+    const limit = Math.min(segment.length, MAX_TOKEN_LENGTH);
+    for (let i = 1; i <= limit; i += 1) {
+      collector.add(segment.substring(0, i));
+      if (collector.size >= MAX_KEYWORD_TOKENS) {
+        return;
+      }
+    }
+    if (collector.size >= MAX_KEYWORD_TOKENS) {
+      return;
+    }
+  }
+}
+
+function buildKeywords(post: PostSnapshotData, tags: string[]): string[] {
+  const tokens = new Set<string>();
+  if (typeof post.authorNickname === "string") {
+    tokenize(post.authorNickname, tokens);
+  }
+  if (typeof post.text === "string") {
+    tokenize(post.text, tokens);
+  }
+  for (const tag of tags) {
+    tokenize(tag, tokens);
+    if (tokens.size >= MAX_KEYWORD_TOKENS) {
+      break;
+    }
+  }
+  return Array.from(tokens).slice(0, MAX_KEYWORD_TOKENS);
+}
+
+function arraysEqual(a: unknown, b: unknown): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+    return false;
+  }
+  return a.every((value, index) => value === b[index]);
+}
+
+export const onLikeWrite = onDocumentWritten({
+  document: "likes/{likeId}",
+}, async (event) => {
+  const before = event.data?.before;
+  const after = event.data?.after;
+  const beforeExists = before?.exists ?? false;
+  const afterExists = after?.exists ?? false;
+
+  if (beforeExists === afterExists) {
+    return;
+  }
+
+  const snapshot = afterExists ? after : before;
+  const data = snapshot?.data() as {postId?: string} | undefined;
+  const postId = data?.postId;
+  if (!postId) {
+    logger.warn("Like document missing postId", event.params.likeId);
+    return;
+  }
+
+  const delta = afterExists ? 1 : -1;
+  const postRef = db.collection("posts").doc(postId);
+
+  await db.runTransaction(async (transaction) => {
+    const postSnap = await transaction.get(postRef);
+    if (!postSnap.exists) {
+      logger.warn("Post not found while processing like", postId);
+      return;
+    }
+    const postData = postSnap.data() as PostSnapshotData;
+    const likeCount = Math.max(0, (postData.likeCount ?? 0) + delta);
+    const commentCount = postData.commentCount ?? 0;
+    const viewCount = postData.viewCount ?? 0;
+    const hotScore = calculateHotScore(likeCount, commentCount, viewCount, postData.createdAt);
+
+    transaction.update(postRef, {
+      likeCount,
+      hotScore,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  });
+});
+
+export const onCommentWrite = onDocumentWritten({
+  document: "posts/{postId}/comments/{commentId}",
+}, async (event) => {
+  const postId = event.params.postId as string;
+  const before = event.data?.before;
+  const after = event.data?.after;
+  const beforeExists = before?.exists ?? false;
+  const afterExists = after?.exists ?? false;
+  const delta = afterExists && !beforeExists ? 1 : !afterExists && beforeExists ? -1 : 0;
+
+  const postRef = db.collection("posts").doc(postId);
+
+  if (delta !== 0) {
+    await db.runTransaction(async (transaction) => {
+      const postSnap = await transaction.get(postRef);
+      if (!postSnap.exists) {
+        logger.warn("Post not found while processing comment", postId);
+        return;
+      }
+      const postData = postSnap.data() as PostSnapshotData;
+      const likeCount = postData.likeCount ?? 0;
+      const commentCount = Math.max(0, (postData.commentCount ?? 0) + delta);
+      const viewCount = postData.viewCount ?? 0;
+      const hotScore = calculateHotScore(likeCount, commentCount, viewCount, postData.createdAt);
+
+      transaction.update(postRef, {
+        commentCount,
+        hotScore,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    });
+  }
+
+  const commentsSnap = await db
+    .collection("posts")
+    .doc(postId)
+    .collection("comments")
+    .where("deleted", "==", false)
+    .orderBy("likeCount", "desc")
+    .orderBy("createdAt", "asc")
+    .limit(1)
+    .get();
+
+  if (commentsSnap.empty) {
+    await postRef.update({topComment: null});
+    return;
+  }
+
+  const topDoc = commentsSnap.docs[0];
+  const topData = topDoc.data() as CommentSnapshotData;
+  await postRef.update({
+    topComment: {
+      id: topDoc.id,
+      text: topData.text ?? "",
+      likeCount: topData.likeCount ?? 0,
+      authorNickname: topData.authorNickname ?? "익명",
+    },
+  });
+});
+
+export const onPostWrite = onDocumentWritten({
+  document: "posts/{postId}",
+}, async (event) => {
+  const after = event.data?.after;
+  if (!after?.exists) {
+    return;
+  }
+
+  const postData = after.data() as PostSnapshotData;
+  const normalizedTags = normalizeTags(postData.tags);
+  const keywords = buildKeywords(postData, normalizedTags);
+
+  const updates: Record<string, unknown> = {};
+  if (!arraysEqual(postData.tags, normalizedTags)) {
+    updates.tags = normalizedTags;
+  }
+  if (!arraysEqual(postData.keywords, keywords)) {
+    updates.keywords = keywords;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    updates.updatedAt = FieldValue.serverTimestamp();
+    await after.ref.update(updates);
+  }
+
+  const isCreate = !(event.data?.before?.exists ?? false);
+  if (isCreate && keywords.length > 0) {
+    const batch = db.batch();
+    const suggestions = db.collection("search_suggestions");
+    keywords.slice(0, 50).forEach((token) => {
+      const suggestionRef = suggestions.doc(token);
+      batch.set(
+        suggestionRef,
+        {
+          count: FieldValue.increment(1),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        {merge: true},
+      );
+    });
+    await batch.commit();
+  }
+});

--- a/lib/core/utils/hot_score.dart
+++ b/lib/core/utils/hot_score.dart
@@ -23,7 +23,7 @@ class HotScoreCalculator {
     final DateTime reference = now ?? DateTime.now();
     final Duration age = reference.difference(createdAt);
     final double hours = age.inMinutes / 60.0;
-    final double timeDecay = pow(2, hours / decayLambda) as num;
+    final double timeDecay = pow(2, hours / decayLambda).toDouble();
     final double base =
         likeCount * likeWeight + commentCount * commentWeight + viewCount * viewWeight;
     if (timeDecay <= 0) {

--- a/lib/di/di.dart
+++ b/lib/di/di.dart
@@ -22,6 +22,7 @@ import '../features/matching/data/matching_repository.dart';
 import '../features/community/data/community_repository.dart';
 import '../features/community/presentation/cubit/community_feed_cubit.dart';
 import '../features/community/presentation/cubit/board_catalog_cubit.dart';
+import '../features/community/presentation/cubit/board_feed_cubit.dart';
 import '../features/blind/data/blind_repository.dart';
 import '../features/blind/presentation/cubit/blind_feed_cubit.dart';
 import '../features/matching/presentation/cubit/matching_cubit.dart';
@@ -61,6 +62,9 @@ Future<void> configureDependencies() async {
     ..registerLazySingleton<CommunityRepository>(CommunityRepository.new)
     ..registerFactory<BoardCatalogCubit>(
       () => BoardCatalogCubit(repository: getIt()),
+    )
+    ..registerFactory<BoardFeedCubit>(
+      () => BoardFeedCubit(repository: getIt(), authCubit: getIt()),
     )
     ..registerLazySingleton<BlindRepository>(BlindRepository.new)
     ..registerFactory<MatchingCubit>(

--- a/lib/features/community/data/community_repository.dart
+++ b/lib/features/community/data/community_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -509,6 +510,14 @@ class CommunityRepository {
     }
     final QuerySnapshot<JsonMap> snapshot = await query.get();
     return snapshot.docs.map(Board.fromSnapshot).toList(growable: false);
+  }
+
+  Future<Board?> fetchBoardById(String boardId) async {
+    final DocumentSnapshot<JsonMap> snapshot = await _boardsRef.doc(boardId).get();
+    if (!snapshot.exists) {
+      return null;
+    }
+    return Board.fromSnapshot(snapshot);
   }
 
   Stream<List<Board>> watchBoards({bool includeHidden = false}) {

--- a/lib/features/community/presentation/cubit/post_composer_cubit.dart
+++ b/lib/features/community/presentation/cubit/post_composer_cubit.dart
@@ -260,7 +260,7 @@ class PostComposerCubit extends Cubit<PostComposerState> {
     int? width;
     int? height;
     try {
-      final ui.Image decoded = await decodeImageFromList(bytes);
+      final ui.Image decoded = await ui.decodeImageFromList(bytes);
       width = decoded.width;
       height = decoded.height;
     } catch (_) {

--- a/lib/features/matching/data/matching_repository.dart
+++ b/lib/features/matching/data/matching_repository.dart
@@ -8,6 +8,10 @@ import '../domain/entities/match_profile.dart';
 
 typedef JsonMap = Map<String, Object?>;
 
+typedef DocSnapshotJson = DocumentSnapshot<JsonMap>;
+
+typedef QueryDocumentSnapshotJson = QueryDocumentSnapshot<JsonMap>;
+
 class MatchRequestResult {
   const MatchRequestResult({required this.isSuccessful, required this.message});
 

--- a/lib/features/profile/data/user_profile_repository.dart
+++ b/lib/features/profile/data/user_profile_repository.dart
@@ -9,6 +9,10 @@ import '../domain/user_profile.dart';
 
 typedef JsonMap = Map<String, Object?>;
 
+typedef QueryJson = Query<JsonMap>;
+
+typedef QueryDocumentSnapshotJson = QueryDocumentSnapshot<JsonMap>;
+
 class UserProfileRepository {
   UserProfileRepository({
     FirebaseFirestore? firestore,

--- a/storage.rules
+++ b/storage.rules
@@ -1,10 +1,35 @@
 rules_version = '2';
 
-// Craft rules based on data in your Firestore database
-// allow write: if firestore.get(
-//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    function isValidImageUpload() {
+      return request.resource != null &&
+        request.resource.size < 10 * 1024 * 1024 &&
+        request.resource.contentType.matches('image/.*');
+    }
+
+    function canWriteImage(uid) {
+      return isOwner(uid) && (request.resource == null || isValidImageUpload());
+    }
+
+    match /post_images/{userId}/{postId}/{fileName} {
+      allow read: if true;
+      allow write: if canWriteImage(userId);
+    }
+
+    match /profile_images/{userId}/{fileName} {
+      allow read: if true;
+      allow write: if canWriteImage(userId);
+    }
+
     match /{allPaths=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Summary
- add repository and cubit helpers to reload board feeds by id, keep bookmarks in sync, and register the cubit with DI
- fix hot score calculation and media decoding so attachments and scoring stay stable
- implement Firestore/Storage security rules, composite indexes, community Cloud Functions, and a Firebase console checklist for deployment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d133c2b4b483339c0f13401ef10835